### PR TITLE
Choice to insert raw emoji

### DIFF
--- a/src/build.js
+++ b/src/build.js
@@ -58,7 +58,7 @@ let writeSnippets = (type, prefix, suffix) => {
         }
 
         snippets[emoji] = {
-            "body": `${unicode}`,
+            "body": `\${1|${unicode},${emoji}|}`,
             "prefix": `ji:${name}`,
             "description": emoji
         };


### PR DESCRIPTION
This is a great extension! There are some cases where it makes sense to allow inserting the raw Emoji character (Markdown, in a raw string, etc.) so this just adds that ability via [snippet choice](https://code.visualstudio.com/docs/editor/userdefinedsnippets#_choice) syntax.

The workflow still works well; users can just press enter quickly to insert the escaped version by default, or press down and enter to choose the raw version.

![gif](https://thumbs.gfycat.com/PiercingExemplaryGoral-size_restricted.gif)