### PR TITLE
Add support for Pug/Jade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.8.0 [#](https://github.com/idleberg/vscode-emoji-code/releases/tag/v0.8.0)
+
+- add support for Pug/Jade
+
 # v0.7.5 [#](https://github.com/idleberg/vscode-emoji-code/releases/tag/v0.7.5)
 
 - update `.vscodeignore`

--- a/package.json
+++ b/package.json
@@ -69,6 +69,10 @@
                 "path": "./snippets/emoji-html.json"
             },
             {
+                "language": "jade",
+                "path": "./snippets/emoji-html.json"
+            },
+            {
                 "language": "coffeescript",
                 "path": "./snippets/emoji-javascript.json"
             },


### PR DESCRIPTION
Simply adds support for Pug and Jade files, which use the same language title in VSCode.